### PR TITLE
update module path

### DIFF
--- a/cmd/moleculec-es/main.go
+++ b/cmd/moleculec-es/main.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/xxuejie/moleculec-es/pkg/generator"
+	"github.com/nervosnetwork/moleculec-es/pkg/generator"
 )
 
 var inputFile = flag.String("inputFile", "", "Input file to use")

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/xxuejie/moleculec-es
+module github.com/nervosnetwork/moleculec-es
 
 go 1.13
 


### PR DESCRIPTION
this solves the problem when using `go install`

input:
```bash
go install github.com/nervosnetwork/moleculec-es/cmd/moleculec-es@0.3.1
```
output:
```
go: github.com/nervosnetwork/moleculec-es/cmd/moleculec-es@0.3.1: github.com/nervosnetwork/moleculec-es@v0.0.0-20201228025044-2f74b3572f17: parsing go.mod:
	module declares its path as: github.com/xxuejie/moleculec-es
	        but was required as: github.com/nervosnetwork/moleculec-es
```