### PR TITLE
feat: support custom union id

### DIFF
--- a/cmd/moleculec-es/main.go
+++ b/cmd/moleculec-es/main.go
@@ -26,9 +26,14 @@ func main() {
 	}
 
 	var schema generator.Schema
+	var schemaOld generator.SchemaOld
 	err = json.Unmarshal(content, &schema)
 	if err != nil {
-		log.Fatal(err)
+		err = json.Unmarshal(content, &schemaOld)
+		if err != nil {
+			log.Fatal(err)
+		}
+		schema = schemaOld.ChangeToNew()
 	}
 
 	writer := os.Stdout

--- a/pkg/generator/types.go
+++ b/pkg/generator/types.go
@@ -27,6 +27,15 @@ type UnionItems struct {
 	Id   uint64 `json:"id"`
 }
 
+type DeclarationOld struct {
+	Type      string   `json:"type"`
+	Name      string   `json:"name"`
+	Item      string   `json:"item"`
+	Items     []string `json:"items"`
+	ItemCount int      `json:"item_count"`
+	Fields    []Field  `json:"fields"`
+}
+
 type SyntaxVersion struct {
 	Version uint64 `json:"version"`
 }
@@ -37,6 +46,11 @@ type Schema struct {
 	Declarations  []Declaration `json:"declarations"`
 }
 
+type SchemaOld struct {
+	Namespace    string           `json:"namespace"`
+	Declarations []DeclarationOld `json:"declarations"`
+}
+
 func (s Schema) FindDeclaration(itemName string) (Declaration, error) {
 	for _, declaration := range s.Declarations {
 		if declaration.Name == itemName {
@@ -44,4 +58,26 @@ func (s Schema) FindDeclaration(itemName string) (Declaration, error) {
 		}
 	}
 	return Declaration{}, fmt.Errorf("Cannot find type %s!", itemName)
+}
+
+func (s SchemaOld) ChangeToNew() Schema {
+	var de []Declaration
+	for _, item := range s.Declarations {
+		de = append(de, item.ChangeToNew())
+	}
+	return Schema{
+		SyntaxVersion: SyntaxVersion{Version: 1},
+		Namespace:     s.Namespace,
+		Declarations:  de,
+	}
+}
+
+func (de DeclarationOld) ChangeToNew() Declaration {
+	var unionItems []UnionItems
+
+	for i, item := range de.Items {
+		unionItems = append(unionItems, UnionItems{Id: uint64(i), Type: item})
+	}
+
+	return Declaration{Type: de.Type, Name: de.Name, Item: de.Item, Items: unionItems, Fields: de.Fields}
 }

--- a/pkg/generator/types.go
+++ b/pkg/generator/types.go
@@ -14,17 +14,27 @@ type Field struct {
 }
 
 type Declaration struct {
-	Type      string   `json:"type"`
-	Name      string   `json:"name"`
-	Item      string   `json:"item"`
-	Items     []string `json:"items"`
-	ItemCount int      `json:"item_count"`
-	Fields    []Field  `json:"fields"`
+	Type      string       `json:"type"`
+	Name      string       `json:"name"`
+	Item      string       `json:"item"`
+	Items     []UnionItems `json:"items"`
+	ItemCount int          `json:"item_count"`
+	Fields    []Field      `json:"fields"`
+}
+
+type UnionItems struct {
+	Type string `json:"typ"`
+	Id   uint64 `json:"id"`
+}
+
+type SyntaxVersion struct {
+	Version uint64 `json:"version"`
 }
 
 type Schema struct {
-	Namespace    string        `json:"namespace"`
-	Declarations []Declaration `json:"declarations"`
+	SyntaxVersion SyntaxVersion `json:"syntax_version"`
+	Namespace     string        `json:"namespace"`
+	Declarations  []Declaration `json:"declarations"`
 }
 
 func (s Schema) FindDeclaration(itemName string) (Declaration, error) {

--- a/pkg/test/blockchain.json
+++ b/pkg/test/blockchain.json
@@ -1,4 +1,7 @@
 {
+  "syntax_version": {
+    "version": 1
+  },
   "namespace": "blockchain",
   "imports": [],
   "declarations": [

--- a/pkg/test/complex.json
+++ b/pkg/test/complex.json
@@ -1,4 +1,7 @@
 {
+  "syntax_version": {
+    "version": 1
+  },
   "namespace": "complex",
   "imports": [],
   "declarations": [
@@ -56,25 +59,46 @@
       "type": "union",
       "name": "BaseData",
       "items": [
-        "Bytes",
-        "Uint32",
-        "Uint64"
+        {
+          "typ": "Bytes",
+          "id": 0
+        },
+        {
+          "typ": "Uint32",
+          "id": 1
+        },
+        {
+          "typ": "Uint64",
+          "id": 2
+        }
       ]
     },
     {
       "type": "union",
       "name": "BigNumber",
       "items": [
-        "Uint64",
-        "Uint128"
+        {
+          "typ": "Uint64",
+          "id": 0
+        },
+        {
+          "typ": "Uint128",
+          "id": 1
+        }
       ]
     },
     {
       "type": "union",
       "name": "AllRoad",
       "items": [
-        "BaseData",
-        "BigNumber"
+        {
+          "typ": "BaseData",
+          "id": 0
+        },
+        {
+          "typ": "BigNumber",
+          "id": 1
+        }
       ]
     },
     {

--- a/pkg/test/embedded.json
+++ b/pkg/test/embedded.json
@@ -1,5 +1,8 @@
 {
-  "namespace": "embeded",
+  "syntax_version": {
+    "version": 1
+  },
+  "namespace": "embedded",
   "imports": [],
   "declarations": [
     {

--- a/pkg/test/union_vector.json
+++ b/pkg/test/union_vector.json
@@ -1,4 +1,7 @@
 {
+  "syntax_version": {
+    "version": 1
+  },
   "namespace": "union_vector",
   "imports": [],
   "declarations": [
@@ -56,9 +59,18 @@
       "type": "union",
       "name": "Mixed",
       "items": [
-        "Bytes",
-        "Uint32",
-        "Uint64"
+        {
+          "typ": "Bytes",
+          "id": 0
+        },
+        {
+          "typ": "Uint32",
+          "id": 1
+        },
+        {
+          "typ": "Uint64",
+          "id": 2
+        }
       ]
     },
     {


### PR DESCRIPTION
Fix #8 

Support [custom union id](https://github.com/nervosnetwork/molecule/pull/65) and [syntax version](https://github.com/nervosnetwork/molecule/pull/64) parse, ~but unfortunately, this will result in the inability to parse the syntax tree json file generated by moleculec before 0.7.5~